### PR TITLE
Refactor provider

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -1,5 +1,4 @@
 resource "azurerm_resource_group" "bastion" {
-  provider  = azurerm.cluster-provider-subscription
   name      = "${var.infrastructurename}-bastion"
   location  = "${var.location}"
 
@@ -13,7 +12,6 @@ resource "azurerm_resource_group" "bastion" {
 }
 
 resource "azurerm_subnet" "bastion-subnet" {
-  provider             = azurerm.cluster-provider-subscription
   name                 = "AzureBastionSubnet"
   resource_group_name  = azurerm_resource_group.network.name
   virtual_network_name = azurerm_virtual_network.simphera-vnet.name
@@ -22,7 +20,6 @@ resource "azurerm_subnet" "bastion-subnet" {
 
 resource "azurerm_public_ip" "bastion-pubip" {
   count               = "${var.licenseServer ? 1 : 0}"
-  provider            = azurerm.cluster-provider-subscription
   name                = "bastion-pubip"
   location            = "${var.location}"
   resource_group_name = azurerm_resource_group.bastion.name
@@ -40,7 +37,6 @@ resource "azurerm_public_ip" "bastion-pubip" {
 
 resource "azurerm_bastion_host" "bastion-host" {
   count               = "${var.licenseServer ? 1 : 0}"
-  provider            = azurerm.cluster-provider-subscription
   name                = "bastion-host"
   location            = "${var.location}"
   resource_group_name = azurerm_resource_group.bastion.name

--- a/k8s.tf
+++ b/k8s.tf
@@ -1,12 +1,10 @@
 resource "azurerm_resource_group" "aks" {
-  provider  = azurerm.cluster-provider-subscription
   name      = "${var.infrastructurename}-aks"
   location  = "${var.location}"
   tags      = var.tags
 }
 
 resource "azurerm_subnet" "default-node-pool-subnet" {
-  provider             = azurerm.cluster-provider-subscription
   name                 = "default-node-pool-subnet"
   resource_group_name  = azurerm_virtual_network.simphera-vnet.resource_group_name
   virtual_network_name = azurerm_virtual_network.simphera-vnet.name
@@ -14,7 +12,6 @@ resource "azurerm_subnet" "default-node-pool-subnet" {
 }
 
 resource "azurerm_subnet" "execution-nodes-subnet" {
-  provider             = azurerm.cluster-provider-subscription
   name                 = "execution-nodes-subnet"
   resource_group_name  = azurerm_virtual_network.simphera-vnet.resource_group_name
   virtual_network_name = azurerm_virtual_network.simphera-vnet.name
@@ -22,7 +19,6 @@ resource "azurerm_subnet" "execution-nodes-subnet" {
 }
 
 resource "azurerm_kubernetes_cluster" "aks" {
-  provider            = azurerm.cluster-provider-subscription
   name                = "${var.infrastructurename}-aks"
   location            = azurerm_resource_group.aks.location
   resource_group_name = azurerm_resource_group.aks.name
@@ -100,7 +96,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "execution-nodes" {
-  provider              = azurerm.cluster-provider-subscription
   name                  = "execnodes"
   mode                  = "User"
   orchestrator_version  = var.kubernetesVersion

--- a/license-server.tf
+++ b/license-server.tf
@@ -1,6 +1,5 @@
 resource "azurerm_resource_group" "license-server" {
   count     = "${var.licenseServer ? 1 : 0}"
-  provider  = azurerm.cluster-provider-subscription
   name      = "${var.infrastructurename}-license-server"
   location  = "${var.location}"
 
@@ -15,7 +14,6 @@ resource "azurerm_resource_group" "license-server" {
 
 resource "azurerm_subnet" "license-server-subnet" {
   count                = "${var.licenseServer ? 1 : 0}"
-  provider             = azurerm.cluster-provider-subscription
   name                 = "license-server-subnet"
   resource_group_name  = azurerm_resource_group.network.name
   virtual_network_name = azurerm_virtual_network.simphera-vnet.name
@@ -25,7 +23,6 @@ resource "azurerm_subnet" "license-server-subnet" {
 # Virtual machine using Azure Bastion via private IP address
 resource "azurerm_network_interface" "license-server-nic" {
   count               = "${var.licenseServer ? 1 : 0}"
-  provider            = azurerm.cluster-provider-subscription
   name                = "license-server-nic"
   resource_group_name = azurerm_resource_group.license-server[0].name
   location            = "${var.location}"
@@ -47,7 +44,6 @@ resource "azurerm_network_interface" "license-server-nic" {
 
 resource "azurerm_network_security_group" "license-server-nsg" {
   count               = "${var.licenseServer ? 1 : 0}"
-  provider            = azurerm.cluster-provider-subscription
   name                = "license-server-nsg"
   location            = "${var.location}"
   resource_group_name = azurerm_resource_group.license-server[0].name
@@ -87,7 +83,6 @@ resource "azurerm_network_security_group" "license-server-nsg" {
 
 resource "azurerm_network_interface_security_group_association" "ni-license-server-sga" {
   count                     = "${var.licenseServer ? 1 : 0}"
-  provider                  = azurerm.cluster-provider-subscription
   network_interface_id      = azurerm_network_interface.license-server-nic.0.id
   network_security_group_id = azurerm_network_security_group.license-server-nsg.0.id
 }
@@ -95,7 +90,6 @@ resource "azurerm_network_interface_security_group_association" "ni-license-serv
 
 resource "azurerm_windows_virtual_machine" "license-server" {
   count               = "${var.licenseServer ? 1 : 0}"
-  provider            = azurerm.cluster-provider-subscription
   resource_group_name = azurerm_resource_group.license-server[0].name
   name                = "license-server"
   location            = "${var.location}"

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -1,6 +1,5 @@
 data "azurerm_log_analytics_workspace" "log-analytics-workspace" {
   count               = "${var.logAnalyticsWorkspaceName != "" ? 1 : 0}"
-  provider            = azurerm.cluster-provider-subscription
   name                = var.logAnalyticsWorkspaceName
   resource_group_name = var.logAnalyticsWorkspaceResourceGroupName
 }

--- a/main.tf
+++ b/main.tf
@@ -7,20 +7,8 @@ terraform {
   }
 }
 
-locals {
-  subscriptionId = var.subscriptionId
+provider "azurerm" {
+  subscription_id = var.subscriptionId
   environment = var.environment
-}  
-
-provider "azurerm" {
-  alias  = "cluster-provider-subscription"
-  subscription_id = local.subscriptionId
-  environment = local.environment
-  features {}
-}
-
-# The following block is needed to get around the following error:
-# Error: Invalid required_providers object
-provider "azurerm" {
   features {}
 }

--- a/network.tf
+++ b/network.tf
@@ -1,12 +1,10 @@
 resource "azurerm_resource_group" "network" {
-  provider  = azurerm.cluster-provider-subscription
   name      = "${var.infrastructurename}-network"
   location  = "${var.location}"
   tags      = var.tags
 }
 
 resource "azurerm_virtual_network" "simphera-vnet" {
-  provider            = azurerm.cluster-provider-subscription
   name                = "simphera-vnet"
   location            = azurerm_resource_group.network.location
   resource_group_name = azurerm_resource_group.network.name
@@ -23,7 +21,6 @@ resource "azurerm_virtual_network" "simphera-vnet" {
 }
 
 resource "azurerm_subnet" "paas-services-subnet" {
-  provider             = azurerm.cluster-provider-subscription
   name                 = "paas-services-subnet"
   resource_group_name  = azurerm_resource_group.network.name
   virtual_network_name = azurerm_virtual_network.simphera-vnet.name

--- a/postgres-network.tf
+++ b/postgres-network.tf
@@ -1,5 +1,4 @@
 resource "azurerm_private_dns_zone" "postgresql-privatelink-dns-zone" {
-  provider             = azurerm.cluster-provider-subscription
   name                 = "privatelink.postgres.database.azure.com"
   resource_group_name  = azurerm_resource_group.network.name
   tags                 = var.tags
@@ -12,7 +11,6 @@ resource "azurerm_private_dns_zone" "postgresql-privatelink-dns-zone" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "postgresql-privatelink-network-link" {
-  provider              = azurerm.cluster-provider-subscription
   name                  = "postgresql-privatelink-network-link"
   resource_group_name   = azurerm_resource_group.network.name
   private_dns_zone_name = azurerm_private_dns_zone.postgresql-privatelink-dns-zone.name


### PR DESCRIPTION
We only need a single Azure provide in this terraform configuration. However, explicit provider references have been used in the past. They are not needed and also didn't work correctly for submodules.