### PR TITLE
Changes bastion ressource group creation

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -24,7 +24,7 @@ resource "azurerm_public_ip" "bastion-pubip" {
   count               = var.licenseServer ? 1 : 0
   name                = "bastion-pubip"
   location            = var.location
-  resource_group_name = azurerm_resource_group.bastion.name
+  resource_group_name = azurerm_resource_group.bastion.0.name
   allocation_method   = "Static"
   sku                 = "Standard"
 
@@ -41,11 +41,11 @@ resource "azurerm_bastion_host" "bastion-host" {
   count               = var.licenseServer ? 1 : 0
   name                = "bastion-host"
   location            = var.location
-  resource_group_name = azurerm_resource_group.bastion.name
+  resource_group_name = azurerm_resource_group.bastion.0.name
 
   ip_configuration {
     name                 = "configuration"
-    subnet_id            = azurerm_subnet.bastion-subnet.id
+    subnet_id            = azurerm_subnet.bastion-subnet.0.id
     public_ip_address_id = azurerm_public_ip.bastion-pubip.0.id
   }
 


### PR DESCRIPTION
When not deploying a license server, you still end up with an empty ressource group with bastion it its name. This should fix this.