### PR TITLE
kubernetes version 1.20.7 not supported in westeurope

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "logAnalyticsWorkspaceResourceGroupName" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the AKS cluster."
-  default     = "1.20.7"
+  default     = "1.20.13"
 }
 
 variable "simpheraInstances" {


### PR DESCRIPTION
│ Error: creating Managed Kubernetes Cluster "simphera-sswb-aks" (Resource Group "simphera-sswb-aks"): containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request:
StatusCode=400 -- Original Error: Code="AgentPoolK8sVersionNotSupported" Message="Version 1.20.7 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list"

See https://github.com/dspace-group/simphera-reference-architecture-azure/issues/29