### PR TITLE
Add couchbackup outputs

### DIFF
--- a/modules/simphera_instance/couchbackup.tf
+++ b/modules/simphera_instance/couchbackup.tf
@@ -46,15 +46,15 @@ resource "azurerm_storage_share" "couchbackup-share" {
   }
 }
 
-output "couchbackup_storage_account_name" {
+output "couchbackup_storage_name" {
   value = azurerm_storage_account.couchbackup_storage_account.name
 }
 
-output "couchbackup_storage_account_account_key" {
+output "couchbackup_storage_account_key" {
   value     = azurerm_storage_account.couchbackup_storage_account.primary_access_key
   sensitive = true
 }
 
-output "couchbackup_storage_account_share_name" {
+output "couchbackup_storage_share_name" {
   value = azurerm_storage_share.couchbackup-share.name
 }

--- a/modules/simphera_instance/couchbackup.tf
+++ b/modules/simphera_instance/couchbackup.tf
@@ -50,7 +50,7 @@ output "couchbackup_storage_account_name" {
   value = azurerm_storage_account.couchbackup_storage_account.name
 }
 
-output "couchbackup_storage_account_account-key" {
+output "couchbackup_storage_account_account_key" {
   value     = azurerm_storage_account.couchbackup_storage_account.primary_access_key
   sensitive = true
 }

--- a/modules/simphera_instance/couchbackup.tf
+++ b/modules/simphera_instance/couchbackup.tf
@@ -45,3 +45,16 @@ resource "azurerm_storage_share" "couchbackup-share" {
     }
   }
 }
+
+output "couchbackup_storage_account_name" {
+  value = azurerm_storage_account.couchbackup_storage_account.name
+}
+
+output "couchbackup_storage_account_account-key" {
+  value     = azurerm_storage_account.couchbackup_storage_account.primary_access_key
+  sensitive = true
+}
+
+output "couchbackup_storage_account_share_name" {
+  value = azurerm_storage_share.couchbackup-share.name
+}

--- a/modules/simphera_instance/postgresql.tf
+++ b/modules/simphera_instance/postgresql.tf
@@ -46,7 +46,7 @@ output "postgresql_server_hostname" {
 
 output "postgresql_server_username" {
   value     = local.fulllogin
-  sensitive = false
+  sensitive = true
 }
 
 output "postgresql_server_password" {

--- a/simphera-instances.tf
+++ b/simphera-instances.tf
@@ -52,3 +52,24 @@ output "minio_storage_passwords" {
   })
   sensitive = true
 }
+
+
+output "couchbackup_storage_names" {
+  value = tomap({
+    for name, instance in module.simphera_instance : name => instance.couchbackup_storage_name
+  })
+}
+
+output "couchbackup_storage_account_keys" {
+  value = tomap({
+    for name, instance in module.simphera_instance : name => instance.couchbackup_storage_account_key
+  })
+  sensitive = true
+
+}
+
+output "couchbackup_storage_share_names" {
+  value = tomap({
+    for name, instance in module.simphera_instance : name => instance.couchbackup_storage_share_name
+  })
+}

--- a/simphera-instances.tf
+++ b/simphera-instances.tf
@@ -53,23 +53,15 @@ output "minio_storage_passwords" {
   sensitive = true
 }
 
-
 output "couchbackup_storage_names" {
-  value = tomap({
-    for name, instance in module.simphera_instance : name => instance.couchbackup_storage_name
-  })
+  value = module.simphera_instance[*].couchbackup_storage_name
 }
 
 output "couchbackup_storage_account_keys" {
-  value = tomap({
-    for name, instance in module.simphera_instance : name => instance.couchbackup_storage_account_key
-  })
+  value     = module.simphera_instance[*].couchbackup_storage_account_key
   sensitive = true
-
 }
 
 output "couchbackup_storage_share_names" {
-  value = tomap({
-    for name, instance in module.simphera_instance : name => instance.couchbackup_storage_share_name
-  })
+  value = module.simphera_instance[*].couchbackup_storage_share_name
 }


### PR DESCRIPTION
These details of the couchbackup storage account are neeed for simphera-quickstart.