### PR TITLE
Update provider versions

### DIFF
--- a/k8s.tf
+++ b/k8s.tf
@@ -65,8 +65,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
     docker_bridge_cidr = "172.17.0.1/16" # MUST NOT collide with the rest of the CIDRs including the cluster's service CIDR and pod CIDR. Default is 172.17.0.1/16
   }
 
-  role_based_access_control_enabled = true
-
   addon_profile {
     aci_connector_linux {
       enabled = false

--- a/k8s.tf
+++ b/k8s.tf
@@ -67,12 +67,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   addon_profile {
 
-
-
-    http_application_routing {
-      enabled = false
-    }
-
     kube_dashboard {
       enabled = false
     }

--- a/k8s.tf
+++ b/k8s.tf
@@ -66,9 +66,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   addon_profile {
-    aci_connector_linux {
-      enabled = false
-    }
 
     azure_policy {
       enabled = false

--- a/k8s.tf
+++ b/k8s.tf
@@ -65,9 +65,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     docker_bridge_cidr = "172.17.0.1/16" # MUST NOT collide with the rest of the CIDRs including the cluster's service CIDR and pod CIDR. Default is 172.17.0.1/16
   }
 
-  role_based_access_control {
-    enabled = true
-  }
+  role_based_access_control_enabled = true
 
   addon_profile {
     aci_connector_linux {

--- a/k8s.tf
+++ b/k8s.tf
@@ -159,7 +159,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "execution-nodes" {
 
   lifecycle {
     ignore_changes = [
-      availability_zones,
+      zones,
       enable_host_encryption,
       enable_node_public_ip,
       vnet_subnet_id,
@@ -195,7 +195,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu-execution-nodes" {
 
   lifecycle {
     ignore_changes = [
-      availability_zones,
+      zones,
       enable_host_encryption,
       enable_node_public_ip,
       vnet_subnet_id,

--- a/k8s.tf
+++ b/k8s.tf
@@ -66,11 +66,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   addon_profile {
-
-    kube_dashboard {
-      enabled = false
-    }
-
     oms_agent {
       enabled                    = var.logAnalyticsWorkspaceName != ""
       log_analytics_workspace_id = var.logAnalyticsWorkspaceName != "" ? data.azurerm_log_analytics_workspace.log-analytics-workspace[0].id : null

--- a/k8s.tf
+++ b/k8s.tf
@@ -77,7 +77,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 }
 
-resource "azurerm_kubernetes_cluster" "aks_with_log" {
+resource "azurerm_kubernetes_cluster" "aks_with_logs" {
   count               = local.log_analytics_enabled ? 1 : 0
   name                = "${var.infrastructurename}-aks"
   location            = azurerm_resource_group.aks.location
@@ -117,11 +117,8 @@ resource "azurerm_kubernetes_cluster" "aks_with_log" {
     docker_bridge_cidr = "172.17.0.1/16" # MUST NOT collide with the rest of the CIDRs including the cluster's service CIDR and pod CIDR. Default is 172.17.0.1/16
   }
 
-  addon_profile {
-    oms_agent {
-      enabled                    = var.logAnalyticsWorkspaceName != ""
-      log_analytics_workspace_id = var.logAnalyticsWorkspaceName != "" ? data.azurerm_log_analytics_workspace.log-analytics-workspace[0].id : null
-    }
+  oms_agent {
+    log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log-analytics-workspace[0].id
   }
 
   tags = var.tags

--- a/k8s.tf
+++ b/k8s.tf
@@ -67,9 +67,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   addon_profile {
 
-    azure_policy {
-      enabled = false
-    }
+
 
     http_application_routing {
       enabled = false

--- a/kubeconf.tf
+++ b/kubeconf.tf
@@ -1,5 +1,5 @@
 resource "local_file" "kubeconfig" {
-  content              = azurerm_kubernetes_cluster.aks.kube_config_raw
+  content              = local.log_analytics_enabled ? azurerm_kubernetes_cluster.aks_with_logs[0].kube_config_raw : azurerm_kubernetes_cluster.aks[0].kube_config_raw
   filename             = "./${var.infrastructurename}.kubeconfig"
   file_permission      = "0600"
   directory_permission = "0755"

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -1,5 +1,5 @@
 data "azurerm_log_analytics_workspace" "log-analytics-workspace" {
-  count               = var.logAnalyticsWorkspaceName != "" ? 1 : 0
+  count               = local.log_analytics_enabled ? 1 : 0
   name                = var.logAnalyticsWorkspaceName
   resource_group_name = var.logAnalyticsWorkspaceResourceGroupName
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.1.0"
+      version = "3.27.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -12,3 +12,8 @@ provider "azurerm" {
   environment     = var.environment
   features {}
 }
+
+locals {
+    log_analytics_enabled = var.logAnalyticsWorkspaceName != "" ? 1 : 0
+
+}

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,6 @@ provider "azurerm" {
 }
 
 locals {
-  log_analytics_enabled = var.logAnalyticsWorkspaceName != "" ? 1 : 0
+  log_analytics_enabled = var.logAnalyticsWorkspaceName != "" ? true : false
 
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.85.0"
+      version = "3.1.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,6 @@ provider "azurerm" {
 }
 
 locals {
-    log_analytics_enabled = var.logAnalyticsWorkspaceName != "" ? 1 : 0
+  log_analytics_enabled = var.logAnalyticsWorkspaceName != "" ? 1 : 0
 
 }

--- a/modules/simphera_instance/main.tf
+++ b/modules/simphera_instance/main.tf
@@ -1,8 +1,3 @@
 terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "2.85.0"
-    }
-  }
+
 }

--- a/modules/simphera_instance/postgresql.tf
+++ b/modules/simphera_instance/postgresql.tf
@@ -27,8 +27,9 @@ resource "azurerm_postgresql_server" "postgresql-server" {
   geo_redundant_backup_enabled = false
   auto_grow_enabled            = false
 
-  public_network_access_enabled = false
-  ssl_enforcement_enabled       = false
+  public_network_access_enabled    = false
+  ssl_enforcement_enabled          = false
+  ssl_minimal_tls_version_enforced = "TLSEnforcementDisabled"
 
   tags = var.tags
 


### PR DESCRIPTION
Upgrades the azurerm provider to version 3.27.0
This changes needed some further adjustments. Now usage of an oms_agent requires a distinct aks-cluster to be created.
Further removes values that were set to their default value.