### PR TITLE
Updated to Kubernetes version 1.21.9

### DIFF
--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -66,7 +66,7 @@ logAnalyticsWorkspaceName = ""
 logAnalyticsWorkspaceResourceGroupName = ""
 
 # The version of the AKS cluster.
-kubernetesVersion = "1.20.13"
+kubernetesVersion = "1.21.9"
 
 # The SIMPHERA instances
 simpheraInstances = {

--- a/variables.tf
+++ b/variables.tf
@@ -129,7 +129,7 @@ variable "logAnalyticsWorkspaceResourceGroupName" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the AKS cluster."
-  default     = "1.20.13"
+  default     = "1.21.9"
 }
 
 variable "simpheraInstances" {


### PR DESCRIPTION
Kubernetes version 1.20.13 reaches end of life in April 2022. The new version has been tested with two SIMPHERA Deployments.