### PR TITLE
Fix license server bug

### DIFF
--- a/license-server.tf
+++ b/license-server.tf
@@ -13,8 +13,8 @@ resource "azurerm_resource_group" "license-server" {
 }
 
 locals {
-  license_server_username = jsondecode(azurerm_key_vault_secret.license-server-secret[0].value)["username"]
-  license_server_password = jsondecode(azurerm_key_vault_secret.license-server-secret[0].value)["password"]
+  license_server_username = (var.licenseServer == true ? jsondecode(azurerm_key_vault_secret.license-server-secret[0].value)["username"] : "")
+  license_server_password = (var.licenseServer == true ? jsondecode(azurerm_key_vault_secret.license-server-secret[0].value)["password"] : "")
 }
 
 


### PR DESCRIPTION
When the license server tag is set to variable there is terraform error that local variables for license server username and password are empty.