### PR TITLE
Removes some special characters

### DIFF
--- a/modules/simphera_base/keyvault.tf
+++ b/modules/simphera_base/keyvault.tf
@@ -72,7 +72,7 @@ resource "azurerm_key_vault_key" "azure-disk-encryption" {
 resource "random_password" "license-server-password" {
   length           = 16
   special          = true
-  override_special = "!#$%&*-_=+:?"
+  override_special = "!#%&*-_+?"
   min_lower        = 2
   min_upper        = 2
   min_special      = 2

--- a/modules/simphera_base/modules/simphera_instance/postgresql.tf
+++ b/modules/simphera_base/modules/simphera_instance/postgresql.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "postgres" {
 resource "random_password" "postgresql-password" {
   length           = 16
   special          = true
-  override_special = "!#$%&*-_+:?"
+  override_special = "!#%&*-_+?"
   min_lower        = 2
   min_upper        = 2
   min_special      = 2


### PR DESCRIPTION
Removes $ and : from the list of special characters in passwords as they tend to break when used in different shell environments
