### PR TITLE
k8s 1.28 upgrade + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ As a next step you have to deploy SIMPHERA to the Kubernetes cluster by using th
 | <a name="input_infrastructurename"></a> [infrastructurename](#input\_infrastructurename) | The name of the infrastructure. e.g. simphera-infra | `string` | n/a | yes |
 | <a name="input_keyVaultAuthorizedIpRanges"></a> [keyVaultAuthorizedIpRanges](#input\_keyVaultAuthorizedIpRanges) | List of authorized IP address ranges that are granted access to the Key Vault, e.g. ["198.51.100.0/24"] | `set(string)` | `[]` | no |
 | <a name="input_keyVaultPurgeProtection"></a> [keyVaultPurgeProtection](#input\_keyVaultPurgeProtection) | Specifies whether the Key vault purge protection is enabled. | `bool` | `true` | no |
-| <a name="input_kubernetesVersion"></a> [kubernetesVersion](#input\_kubernetesVersion) | The version of the AKS cluster. | `string` | `"1.24.9"` | no |
+| <a name="input_kubernetesVersion"></a> [kubernetesVersion](#input\_kubernetesVersion) | The version of the AKS cluster. | `string` | `"1.28.3"` | no |
 | <a name="input_licenseServer"></a> [licenseServer](#input\_licenseServer) | Specifies whether a VM for the dSPACE Installation Manager will be deployed. | `bool` | `false` | no |
 | <a name="input_licenseServerIaaSAntimalware"></a> [licenseServerIaaSAntimalware](#input\_licenseServerIaaSAntimalware) | Specifies whether a IaaSAntimalware extension will be installed on license server VM. Depends on licenseServer variable. | `bool` | `true` | no |
 | <a name="input_licenseServerMicrosoftGuestConfiguration"></a> [licenseServerMicrosoftGuestConfiguration](#input\_licenseServerMicrosoftGuestConfiguration) | Specifies whether a Microsoft Guest configuration extension will be installed on license server VM. Depends on licenseServer variable. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.62.1"
+      version = "3.86.0"
     }
     random = {
       version = "3.5.1"

--- a/modules/simphera_base/k8s.tf
+++ b/modules/simphera_base/k8s.tf
@@ -61,7 +61,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   dynamic "api_server_access_profile" {
-    for_each = length(var.apiServerAuthorizedIpRanges) > 0 ? [1] : []
+    for_each = var.apiServerAuthorizedIpRanges == null ? [] : tolist([var.apiServerAuthorizedIpRanges])
     content {
 
       authorized_ip_ranges = var.apiServerAuthorizedIpRanges
@@ -90,7 +90,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
     network_plugin     = "azure"
     service_cidr       = "10.0.64.0/19"  # MUST be smaller than /12
     dns_service_ip     = "10.0.64.10"    # MUST NOT be the first IP address in the address range
-    docker_bridge_cidr = "172.17.0.1/16" # MUST NOT collide with the rest of the CIDRs including the cluster's service CIDR and pod CIDR. Default is 172.17.0.1/16
   }
 
 

--- a/modules/simphera_base/k8s.tf
+++ b/modules/simphera_base/k8s.tf
@@ -87,9 +87,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   network_profile {
-    network_plugin     = "azure"
-    service_cidr       = "10.0.64.0/19"  # MUST be smaller than /12
-    dns_service_ip     = "10.0.64.10"    # MUST NOT be the first IP address in the address range
+    network_plugin = "azure"
+    service_cidr   = "10.0.64.0/19"  # MUST be smaller than /12
+    dns_service_ip = "10.0.64.10"    # MUST NOT be the first IP address in the address range
   }
 
 

--- a/modules/simphera_base/k8s.tf
+++ b/modules/simphera_base/k8s.tf
@@ -88,8 +88,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   network_profile {
     network_plugin = "azure"
-    service_cidr   = "10.0.64.0/19"  # MUST be smaller than /12
-    dns_service_ip = "10.0.64.10"    # MUST NOT be the first IP address in the address range
+    service_cidr   = "10.0.64.0/19" # MUST be smaller than /12
+    dns_service_ip = "10.0.64.10"   # MUST NOT be the first IP address in the address range
   }
 
 

--- a/modules/simphera_base/keyvault.tf
+++ b/modules/simphera_base/keyvault.tf
@@ -26,7 +26,9 @@ resource "azurerm_key_vault" "simphera-key-vault" {
       "List",
       "Delete",
       "Update",
-      "Purge"
+      "Purge",
+      "Recover",
+      "GetRotationPolicy"
     ]
 
     secret_permissions = [

--- a/modules/simphera_base/variables.tf
+++ b/modules/simphera_base/variables.tf
@@ -131,7 +131,7 @@ variable "logAnalyticsWorkspaceResourceGroupName" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the AKS cluster."
-  default     = "1.24.9"
+  default     = "1.28.3"
 }
 
 variable "kubernetesTier" {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -69,7 +69,7 @@ logAnalyticsWorkspaceName = ""
 logAnalyticsWorkspaceResourceGroupName = ""
 
 # The version of the AKS cluster.
-kubernetesVersion = "1.24.10"
+kubernetesVersion = "1.28.3"
 
 # Enable Key Vault purge protection
 keyVaultPurgeProtection = true

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,7 @@ variable "logAnalyticsWorkspaceResourceGroupName" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the AKS cluster."
-  default     = "1.24.9"
+  default     = "1.28.3"
 }
 
 variable "kubernetesTier" {


### PR DESCRIPTION
upgraded k8s to 1.28.3 (EOL: 28/10/2024)  
fixed issues:  
- key permissions in Key Vault aligned with TF docs: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key#example-usage  
- upgraded azure provider to 3.86.0 (latest)  
- handling of authorized_ip_ranges variable; now it works if null, empty (ie []) or valid range is set
- removed docker_bridge_cidr as it is deprecated (since v3.49.0 of provider; https://github.com/hashicorp/terraform-provider-azurerm/pull/20952)
  
Tested with:  
Terraform v1.4.5  
on linux_amd64  
+ provider registry.terraform.io/hashicorp/azurerm v3.86.0  
+ provider registry.terraform.io/hashicorp/local v2.4.0  
+ provider registry.terraform.io/hashicorp/random v3.5.1  