### PR TITLE
Aks upgrade channels

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,5 +53,6 @@ module "simphera_base" {
   keyVaultAuthorizedIpRanges               = var.keyVaultAuthorizedIpRanges
   simpheraInstances                        = var.simpheraInstances
   apiServerAuthorizedIpRanges              = var.apiServerAuthorizedIpRanges
-
+  automaticChannelUpgrade                  = var.automaticChannelUpgrade
+  nodeOsChannelUpgrade                     = var.nodeOsChannelUpgrade
 }

--- a/modules/simphera_base/k8s.tf
+++ b/modules/simphera_base/k8s.tf
@@ -45,14 +45,17 @@ resource "azurerm_subnet" "gpu-nodes-subnet" {
 }
 
 resource "azurerm_kubernetes_cluster" "aks" {
-  name                 = "${var.infrastructurename}-aks"
-  location             = azurerm_resource_group.aks.location
-  resource_group_name  = azurerm_resource_group.aks.name
-  node_resource_group  = "${var.infrastructurename}-aks-node-pools"
-  dns_prefix           = "${var.infrastructurename}-aks"
-  kubernetes_version   = var.kubernetesVersion
-  azure_policy_enabled = true
-  sku_tier             = var.kubernetesTier
+  name                      = "${var.infrastructurename}-aks"
+  location                  = azurerm_resource_group.aks.location
+  resource_group_name       = azurerm_resource_group.aks.name
+  node_resource_group       = "${var.infrastructurename}-aks-node-pools"
+  dns_prefix                = "${var.infrastructurename}-aks"
+  kubernetes_version        = var.kubernetesVersion
+  azure_policy_enabled      = true
+  sku_tier                  = var.kubernetesTier
+  node_os_channel_upgrade   = var.nodeOsChannelUpgrade
+  automatic_channel_upgrade = var.automaticChannelUpgrade
+
   linux_profile {
     admin_username = "simphera"
     ssh_key {

--- a/modules/simphera_base/variables.tf
+++ b/modules/simphera_base/variables.tf
@@ -171,3 +171,25 @@ variable "apiServerAuthorizedIpRanges" {
   description = "List of authorized IP address ranges that are granted access to the Kubernetes API server, e.g. [\"198.51.100.0/24\"]"
   default     = null
 }
+
+variable "automaticChannelUpgrade " {
+  type        = string
+  description = "The upgrade channel for the k8s cluster."
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "patch", "rapid", "node-image", "stable"], var.automaticChannelUpgrade)
+    error_message = "Valid values for var: automaticChannelUpgrade are (none, patch, rapid, node-image, stable)."
+  }
+}
+
+variable "nodeOsChannelUpgrade " {
+  type        = string
+  description = "The upgrade channel for the k8s cluster's nodes os iamges."
+  default     = "None"
+
+  validation {
+    condition     = contains(["Unmanaged", "SecurityPatch", "NodeImage","None"], var.nodeOsChannelUpgrade)
+    error_message = "Valid values for var: automaticChannelUpgrade are (Unmanaged, SecurityPatch, NodeImage,None)."
+  },
+}

--- a/modules/simphera_base/variables.tf
+++ b/modules/simphera_base/variables.tf
@@ -172,7 +172,7 @@ variable "apiServerAuthorizedIpRanges" {
   default     = null
 }
 
-variable "automaticChannelUpgrade " {
+variable "automaticChannelUpgrade" {
   type        = string
   description = "The upgrade channel for the k8s cluster."
   default     = "none"
@@ -183,13 +183,13 @@ variable "automaticChannelUpgrade " {
   }
 }
 
-variable "nodeOsChannelUpgrade " {
+variable "nodeOsChannelUpgrade" {
   type        = string
   description = "The upgrade channel for the k8s cluster's nodes os iamges."
   default     = "None"
 
   validation {
-    condition     = contains(["Unmanaged", "SecurityPatch", "NodeImage","None"], var.nodeOsChannelUpgrade)
+    condition     = contains(["Unmanaged", "SecurityPatch", "NodeImage", "None"], var.nodeOsChannelUpgrade)
     error_message = "Valid values for var: automaticChannelUpgrade are (Unmanaged, SecurityPatch, NodeImage,None)."
-  },
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,3 +182,25 @@ variable "apiServerAuthorizedIpRanges" {
   description = "List of authorized IP address ranges that are granted access to the Kubernetes API server, e.g. [\"198.51.100.0/24\"]"
   default     = null
 }
+
+variable "automaticChannelUpgrade" {
+  type        = string
+  description = "The upgrade channel for the k8s cluster."
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "patch", "rapid", "node-image", "stable"], var.automaticChannelUpgrade)
+    error_message = "Valid values for var: automaticChannelUpgrade are (none, patch, rapid, node-image, stable)."
+  }
+}
+
+variable "nodeOsChannelUpgrade" {
+  type        = string
+  description = "The upgrade channel for the k8s cluster's nodes os iamges."
+  default     = "None"
+
+  validation {
+    condition     = contains(["Unmanaged", "SecurityPatch", "NodeImage", "None"], var.nodeOsChannelUpgrade)
+    error_message = "Valid values for var: automaticChannelUpgrade are (Unmanaged, SecurityPatch, NodeImage,None)."
+  }
+}


### PR DESCRIPTION
Adds two variables to enable the configuration of the upgrade channels for kubernetes and the node os.
The default value is set to the current behavior.