### PR TITLE
Added configurable disk size for all node groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.86.0"
+      version = "3.92.0"
     }
     random = {
       version = "3.5.1"
@@ -29,9 +29,11 @@ module "simphera_base" {
   infrastructurename                       = var.infrastructurename
   tags                                     = var.tags
   linuxNodeSize                            = var.linuxNodeSize
+  linuxNodeDiskSize                        = var.linuxNodeDiskSize
   linuxNodeCountMin                        = var.linuxNodeCountMin
   linuxNodeCountMax                        = var.linuxNodeCountMax
   linuxExecutionNodeSize                   = var.linuxExecutionNodeSize
+  linuxExecutionNodeDiskSize               = var.linuxExecutionNodeDiskSize
   linuxExecutionNodeCountMin               = var.linuxExecutionNodeCountMin
   linuxExecutionNodeCountMax               = var.linuxExecutionNodeCountMax
   linuxExecutionNodeDeallocate             = var.linuxExecutionNodeDeallocate
@@ -39,6 +41,7 @@ module "simphera_base" {
   gpuNodeCountMin                          = var.gpuNodeCountMin
   gpuNodeCountMax                          = var.gpuNodeCountMax
   gpuNodeSize                              = var.gpuNodeSize
+  gpuNodeDiskSize                          = var.gpuNodeDiskSize
   gpuNodeDeallocate                        = var.gpuNodeDeallocate
   ssh_public_key_path                      = var.ssh_public_key_path
   licenseServer                            = var.licenseServer

--- a/modules/simphera_base/k8s.tf
+++ b/modules/simphera_base/k8s.tf
@@ -79,7 +79,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     min_count           = var.linuxNodeCountMin
     max_count           = var.linuxNodeCountMax
     enable_auto_scaling = true
-    os_disk_size_gb     = 128
+    os_disk_size_gb     = var.linuxNodeDiskSize
     type                = "VirtualMachineScaleSets"
     max_pods            = 110
     vnet_subnet_id      = azurerm_subnet.default-node-pool-subnet.id
@@ -119,7 +119,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "execution-nodes" {
   name                  = "execnodes"
   mode                  = "User"
   orchestrator_version  = var.kubernetesVersion
-  os_disk_size_gb       = 128
+  os_disk_size_gb       = var.linuxExecutionNodeDiskSize
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
   min_count             = var.linuxExecutionNodeCountMin
   max_count             = var.linuxExecutionNodeCountMax
@@ -156,7 +156,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu-execution-nodes" {
   name                  = "gpuexecnodes"
   mode                  = "User"
   orchestrator_version  = var.kubernetesVersion
-  os_disk_size_gb       = 128
+  os_disk_size_gb       = var.gpuNodeDiskSize
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
   min_count             = var.gpuNodeCountMin
   max_count             = var.gpuNodeCountMax

--- a/modules/simphera_base/variables.tf
+++ b/modules/simphera_base/variables.tf
@@ -20,6 +20,12 @@ variable "linuxNodeSize" {
   default     = "Standard_D4s_v4"
 }
 
+variable "linuxNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the nodes for the regular services"
+  default     = 200
+}
+
 variable "linuxNodeCountMin" {
   type        = number
   description = "The minimum number of Linux nodes for the regular services"
@@ -36,6 +42,12 @@ variable "linuxExecutionNodeSize" {
   type        = string
   description = "The machine size of the Linux nodes for the job execution"
   default     = "Standard_D16s_v4"
+}
+
+variable "linuxExecutionNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the nodes for the job execution"
+  default     = 200
 }
 
 variable "linuxExecutionNodeCountMin" {
@@ -78,6 +90,12 @@ variable "gpuNodeSize" {
   type        = string
   description = "The machine size of the nodes for the gpu job execution"
   default     = "Standard_NC16as_T4_v3"
+}
+
+variable "gpuNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the nodes for gpu job execution"
+  default     = 200
 }
 
 variable "gpuNodeDeallocate" {

--- a/variables.tf
+++ b/variables.tf
@@ -160,7 +160,7 @@ variable "logAnalyticsWorkspaceResourceGroupName" {
 variable "kubernetesVersion" {
   type        = string
   description = "The version of the AKS cluster."
-  default     = "1.28.3"
+  default     = "1.28.9"
 }
 
 variable "kubernetesTier" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "linuxNodeSize" {
   default     = "Standard_D4s_v4"
 }
 
+variable "linuxNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the nodes for the regular services"
+  default     = 200
+}
+
 variable "linuxNodeCountMin" {
   type        = number
   description = "The minimum number of Linux nodes for the regular services"
@@ -47,6 +53,12 @@ variable "linuxExecutionNodeSize" {
   type        = string
   description = "The machine size of the Linux nodes for the job execution"
   default     = "Standard_D16s_v4"
+}
+
+variable "linuxExecutionNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the nodes for the job execution"
+  default     = 200
 }
 
 variable "linuxExecutionNodeCountMin" {
@@ -89,6 +101,12 @@ variable "gpuNodeSize" {
   type        = string
   description = "The machine size of the nodes for the gpu job execution"
   default     = "Standard_NC16as_T4_v3"
+}
+
+variable "gpuNodeDiskSize" {
+  type        = number
+  description = "The disk size in GiB of the gpu nodes"
+  default     = 200
 }
 
 variable "gpuNodeDeallocate" {


### PR DESCRIPTION
As the title says, node disk size is now configurable (regular nodes, execution nodes and gpu nodes).  
Bumped the azurerm provider to 3.92.0  
Bumped the k8s version to latest patch version, 1.28.9  
Tested to be working.  

Terraform v1.7.1
on linux_amd64
+ provider registry.terraform.io/hashicorp/azurerm v3.92.0
+ provider registry.terraform.io/hashicorp/local v2.4.0
+ provider registry.terraform.io/hashicorp/random v3.5.1